### PR TITLE
add support for sqlite DBs download

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -35,7 +35,7 @@
 2. Add execution permissions to the installation scripts: ```cd on-premise/install/ && chmod +x *.sh```
 3. Run the install-scanoss.sh script: ```sudo ./install-scanoss.sh```
 4. Choose option 1) Install everything
-5. Run the kb-download.sh script: ```./kb-download.sh``` and choose what to download (full KB, an update, or the test KB)
+5. Run the kb-download.sh script: ```./kb-download.sh``` and choose what to download (full KB, an update, the test KB, or a SQLite KB snapshot). If you downloaded a KB update, run the `ldb-import.sh` script included in the download folder to import it into your local LDB.
 6. Installation finished!
 
 ## Introduction
@@ -77,7 +77,7 @@ The following is recommended for running the SCANOSS Applications and SCANOSS Te
 ## Repository Contents
 
 - [install-scanoss.sh](./install-scanoss.sh): bash script for installing SCANOSS (SFTP user setup creation, dependencies installation and application download/install)
-- [kb-download.sh](./kb-download.sh): bash script for downloading the full KB, KB updates, or the test KB from the SCANOSS SFTP server
+- [kb-download.sh](./kb-download.sh): bash script for downloading the full KB, KB updates, the test KB, or a SQLite KB snapshot from the SCANOSS SFTP server. KB update downloads ship with an `ldb-import.sh` helper that imports the update into your local LDB.
 - [test.sh](./test.sh): bash script for verifying the correct installation of SCANOSS and the SCANOSS KB
 - [resources](/resources): directory containing files for testing the installation of SCANOSS and the SCANOSS KB
 - [config.sh](./config.sh): configuration file
@@ -244,8 +244,9 @@ What do you want to download?
   1) Full KB
   2) KB update
   3) Test KB
+  4) SQLite KB
 
-Select [1-3]: 2
+Select [1-4]: 2
 
 SFTP host: sftp.test.xyz
 SFTP port: 12345
@@ -355,6 +356,47 @@ Test KB downloaded to /var/lib/ldb/oss
 
 Finished downloading test KB.
 ```
+
+##### SQLite KB
+
+```
+./kb-download.sh -m sqlite -h sftp.test.xyz -P 12345 -u USER21
+
+SCANOSS Knowledge Base Download
+================================
+Using lftp for downloads (parallel, resumable).
+
+SFTP password:
+
+Fetching available sqlite KB versions...
+
+Available sqlite KB versions:
+-------------------
+  1) 26.04  (latest)
+-------------------
+
+Select a sqlite KB version to download [1-1] (default: 1):
+
+Selected sqlite KB: 26.04
+
+Download directory [.]:
+
+Fetching sqlite KB metadata...
+Sqlite KB size: 1.2G
+Free space:  500G (on /dev/sda1)
+Disk space OK.
+
+lftp parallel threads [25]:
+
+Download sqlite KB 26.04 to ./26.04? [Y/n]
+Downloading kb/sqlite/26.04 with lftp (25 parallel threads, resumable)...
+
+Sqlite KB downloaded to ./26.04
+
+Finished downloading sqlite KB.
+```
+
+The downloaded folder contains all `.sqlite` files the SFTP user has access to (plus `metadata.json`). Different users may see different sets of files depending on their permissions.
 
 #### Verifying a KB Update
 

--- a/install/README.md
+++ b/install/README.md
@@ -121,7 +121,7 @@ After finishing the installation run ```sudo systemctl start scanoss-go-api.serv
 
 ### Knowledge Base Download (kb-download.sh)
 
-The `kb-download.sh` script provides a unified way to download the full KB, a KB update, or the test KB directly from the SCANOSS SFTP server. It connects to the server, lists all available versions, lets you choose which one to download, and checks for sufficient disk space before starting. For updates, a separate import script (`ldb-import.sh`) included in the downloaded folder handles importing into your local LDB.
+The `kb-download.sh` script provides a unified way to download the full KB, a KB update, the test KB, or a SQLite KB snapshot directly from the SCANOSS SFTP server. It connects to the server, lists all available versions, lets you choose which one to download, and checks for sufficient disk space before starting. For updates, a separate import script (`ldb-import.sh`) included in the downloaded folder handles importing into your local LDB.
 
 The **test KB** is a small, pre-built LDB used to verify that your installation is working before loading the full production KB.
 
@@ -163,7 +163,7 @@ All connection details, paths, and the download mode can be passed as arguments 
 
 | Flag | Description |
 |------|-------------|
-| `-m` | Download mode: `full` (full KB), `update` (KB update), or `test` (test KB) |
+| `-m` | Download mode: `full` (full KB), `update` (KB update), `test` (test KB), or `sqlite` (SQLite KB snapshot) |
 | `-h` | SFTP host |
 | `-P` | SFTP port |
 | `-u` | SFTP username |
@@ -175,10 +175,10 @@ All connection details, paths, and the download mode can be passed as arguments 
 
 | Flag | Description |
 |------|-------------|
-| `-V` | KB version (full/update mode); default: latest from `LATEST.txt` on the server |
+| `-V` | KB version (full/update/sqlite mode); default: latest from `LATEST.txt` on the server |
 | `-o` | Destination path. Test mode: test-KB destination. Full mode: `oss` folder destination. (default: `/var/lib/ldb/oss`) |
 | `-r` | Full mode only: destination for non-oss items (default: `/tmp/scanoss_kb_full_<version>`) |
-| `-D` | Update mode only: download base directory (default: `/tmp/scanoss_kb_update`; final path is `<D>/<version>`) |
+| `-D` | Update / sqlite mode: download base directory. Final path is `<D>/<version>`. Defaults: `/tmp/scanoss_kb_update` for update, current directory for sqlite |
 
 **Non-interactive flags**
 
@@ -205,6 +205,14 @@ Any options not provided on the command line will be prompted interactively, unl
 ./kb-download.sh -y -m update -D /opt/scanoss/updates \
     -h sftp.test.xyz -P 12345 -u USER21 -p mypassword
 
+# SQLite KB into the current directory (final path: ./<version>):
+./kb-download.sh -y -m sqlite \
+    -h sftp.test.xyz -P 12345 -u USER21 -p mypassword
+
+# SQLite KB into a specific base directory:
+./kb-download.sh -y -m sqlite -D /opt/scanoss/sqlite \
+    -h sftp.test.xyz -P 12345 -u USER21 -p mypassword
+
 # Test KB:
 ./kb-download.sh -y -m test -h sftp.test.xyz -P 12345 -u USER21 -p mypassword
 ```
@@ -212,14 +220,15 @@ Any options not provided on the command line will be prompted interactively, unl
 #### How it Works
 
 1. **Connection**: the script prompts for (or reads from arguments) the SFTP host, port, username, and password
-2. **Mode selection**: you choose between downloading the full KB, a KB update, or the test KB
-3. **Version discovery** (full/update only): it connects to the SFTP server and lists all available versions of the chosen type, marking which one is the latest. Test KB has no versions — there is only one current test KB on the server.
-4. **Selection** (full/update only): you choose which version to download (defaults to the latest)
+2. **Mode selection**: you choose between downloading the full KB, a KB update, the test KB, or a SQLite KB snapshot
+3. **Version discovery** (full/update/sqlite only): it connects to the SFTP server and lists all available versions of the chosen type, marking which one is the latest. Test KB has no versions — there is only one current test KB on the server.
+4. **Selection** (full/update/sqlite only): you choose which version to download (defaults to the latest)
 5. **Disk space check**: the script fetches the metadata and verifies there is enough free disk space before downloading. If not enough is available, you are warned and asked to confirm before continuing.
 6. **Download**:
    - **For full KB**: the download is split between two destinations. The `oss` folder (the main LDB data) goes to its own destination (default: `/var/lib/ldb/oss`), and all remaining files and folders go to a separate directory (default: `/tmp/scanoss_kb_full_<version>`). Both destinations can be changed when prompted.
    - **For updates**: the whole update folder is downloaded to a single directory (default: `/tmp/scanoss_kb_update/<version>`).
    - **For test KB**: the test KB's `oss` folder is downloaded to a single destination (default: `/var/lib/ldb/oss`). This will populate your LDB with the test data for verification.
+   - **For SQLite KB**: the whole version folder is downloaded to `<base>/<version>` (default base: the current working directory). The folder contains one or more `.sqlite` files plus a `metadata.json`. The script downloads every file you have access to in that folder — different users may see different sets of `.sqlite` files depending on their SFTP permissions.
 7. **Import (updates only)**: after downloading an update, run the `ldb-import.sh` script included in the downloaded folder
 
 #### Example Sessions

--- a/install/kb-download.sh
+++ b/install/kb-download.sh
@@ -5,8 +5,9 @@ set -e
 ###############################################################################
 # SCANOSS Knowledge Base Download Script
 #
-# Downloads the full KB, a KB update, or the test KB from the SCANOSS SFTP
-# server. Supports both lftp (parallel, resumable) and sftp fallback.
+# Downloads the full KB, a KB update, the test KB, or a SQLite KB snapshot
+# from the SCANOSS SFTP server. Supports both lftp (parallel, resumable) and
+# sftp fallback.
 #
 # Usage:
 #   kb-download.sh [-m mode] [-h host] [-P port] [-u user] [-p password]
@@ -26,8 +27,9 @@ SFTP_PORT=""
 REMOTE_PATH_FULL="kb/full"
 REMOTE_PATH_UPDATE="kb/update"
 REMOTE_PATH_TEST="kb/test/oss"
+REMOTE_PATH_SQLITE="kb/sqlite"
 
-MODE=""            # "full", "update", or "test"
+MODE=""            # "full", "update", "test", or "sqlite"
 DOWNLOAD_TOOL=""   # set during init: "lftp" or "sftp"
 SFTP_USER=""
 SFTP_PASS=""
@@ -65,7 +67,7 @@ usage() {
     echo "          [-D path] [-y] [-f]"
     echo
     echo "Connection / mode options:"
-    echo "  -m    Download mode: full, update, or test"
+    echo "  -m    Download mode: full, update, test, or sqlite"
     echo "  -h    SFTP host"
     echo "  -P    SFTP port"
     echo "  -u    SFTP username"
@@ -74,14 +76,15 @@ usage() {
     echo "  -d    Download tool: lftp or sftp"
     echo
     echo "Path / version overrides (skip the matching interactive prompt):"
-    echo "  -V    KB version (full/update mode); default: latest from LATEST.txt"
+    echo "  -V    KB version (full/update/sqlite mode); default: latest from LATEST.txt"
     echo "  -o    Destination path:"
     echo "          test mode -> test-KB destination (default: /var/lib/ldb/oss)"
     echo "          full mode -> 'oss' folder destination (default: /var/lib/ldb/oss)"
     echo "  -r    full mode: destination for non-oss items"
     echo "        (default: /tmp/scanoss_kb_full_<version>)"
-    echo "  -D    update mode: download base directory"
-    echo "        (default: /tmp/scanoss_kb_update; final path is <D>/<version>)"
+    echo "  -D    update/sqlite mode: download base directory"
+    echo "        (default: /tmp/scanoss_kb_update for update, cwd for sqlite;"
+    echo "         final path is <D>/<version>)"
     echo
     echo "Non-interactive flags:"
     echo "  -y    Don't prompt; use defaults for unspecified values, auto-confirm"
@@ -298,14 +301,14 @@ init_download_tool() {
 prompt_missing_mode() {
     if [[ -n "$MODE" ]]; then
         case "$MODE" in
-            full|update|test) ;;
-            *) die "Invalid mode: ${MODE}. Use 'full', 'update', or 'test'." ;;
+            full|update|test|sqlite) ;;
+            *) die "Invalid mode: ${MODE}. Use 'full', 'update', 'test', or 'sqlite'." ;;
         esac
         return
     fi
 
     if [[ -n "$NON_INTERACTIVE" ]]; then
-        die "Mode is required in non-interactive mode. Pass -m full|update|test."
+        die "Mode is required in non-interactive mode. Pass -m full|update|test|sqlite."
     fi
 
     echo
@@ -313,14 +316,16 @@ prompt_missing_mode() {
     echo "  1) Full KB"
     echo "  2) KB update"
     echo "  3) Test KB"
+    echo "  4) SQLite KB"
     echo
     while true; do
-        read -p "Select [1-3]: " choice
+        read -p "Select [1-4]: " choice
         case $choice in
             1) MODE="full"; break ;;
             2) MODE="update"; break ;;
             3) MODE="test"; break ;;
-            *) echo "Please enter 1, 2, or 3." ;;
+            4) MODE="sqlite"; break ;;
+            *) echo "Please enter 1, 2, 3, or 4." ;;
         esac
     done
 }
@@ -459,15 +464,23 @@ kb_download() {
     local mode="$1"
     local remote_path label default_download
 
-    if [[ "$mode" == "full" ]]; then
-        remote_path="$REMOTE_PATH_FULL"
-        label="full KB"
-        default_download="/tmp/scanoss_kb_full"
-    else
-        remote_path="$REMOTE_PATH_UPDATE"
-        label="update"
-        default_download="/tmp/scanoss_kb_update"
-    fi
+    case "$mode" in
+        full)
+            remote_path="$REMOTE_PATH_FULL"
+            label="full KB"
+            default_download="/tmp/scanoss_kb_full"
+            ;;
+        update)
+            remote_path="$REMOTE_PATH_UPDATE"
+            label="update"
+            default_download="/tmp/scanoss_kb_update"
+            ;;
+        sqlite)
+            remote_path="$REMOTE_PATH_SQLITE"
+            label="sqlite KB"
+            default_download="."
+            ;;
+    esac
 
     # Discover available versions
     echo
@@ -691,9 +704,13 @@ kb_download() {
         echo "${label^} downloaded to ${download_dir_path}"
         log "${label^} downloaded to ${download_dir_path}"
         echo
-        echo "Finished downloading update."
-        echo "Please run the ldb-import.sh script provided inside the update folder to import into the KB:"
-        echo "  ${download_dir_path}/ldb-import.sh"
+        if [[ "$mode" == "update" ]]; then
+            echo "Finished downloading update."
+            echo "Please run the ldb-import.sh script provided inside the update folder to import into the KB:"
+            echo "  ${download_dir_path}/ldb-import.sh"
+        else
+            echo "Finished downloading ${label}."
+        fi
     fi
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SQLite KB snapshot download mode to the installer tool.

* **Documentation**
  * Updated installation guide with SQLite mode details, examples, and clarified version/path override behavior.

* **Chores**
  * Adjusted end-of-download messaging so SQLite downloads show a generic completion message (no import instruction).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/scanoss/on-premise/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->