### PR TITLE
Fix/update install scripts

### DIFF
--- a/install/config.sh
+++ b/install/config.sh
@@ -1,28 +1,32 @@
-# config.sh
+#!/bin/bash
+# config.sh — SCANOSS On-Premise Installation Configuration
 
-# Application configuration
-
+# Application
 APP_NAME="scanoss"
 APP_DIR="/opt/$APP_NAME"
 LOG_FILE="/var/log/$APP_NAME-install.log"
-RUNTIME_USER=scanoss
-VERSION="latest"
+RUNTIME_USER="scanoss"
 
-# Knowledge base configuration
+# Knowledge base
+LDB_LOCATION="/var/lib/ldb"
 
-LDB_LOCATION=/var/lib/ldb
+# SFTP defaults
+SFTP_HOST="sftp.scanoss.com"
+SFTP_PORT="49322"
+SFTP_USER=""
+SFTP_PASSWORD=""
 
-# SFTP credentials
-SCANOSS_SFTP_USER=""
-SCANOSS_SFTP_PASSWORD=""
+# Versions — "latest" follows the symlink on SFTP, or specify e.g. "5.4.25"
+ENGINE_VERSION="latest"
+LDB_VERSION="latest"
+API_VERSION="latest"
+ENCODER_VERSION="latest"
 
-# System information
+# System (auto-detected)
 OS=""
 
-# Installation testing
-TEST_FILE_NAME="file_match.wfp"
-
+# Logging
 function log {
-  local MESSAGE=$1
-  echo "$(date +'%Y-%m-%d %H:%M:%S') - $MESSAGE" >> $LOG_FILE
+  local MESSAGE="$1"
+  echo "$(date +'%Y-%m-%d %H:%M:%S') - $MESSAGE" | tee -a "$LOG_FILE"
 }

--- a/install/install-scanoss.sh
+++ b/install/install-scanoss.sh
@@ -256,7 +256,8 @@ install_api() {
     tmpdir=$(mktemp -d)
     tar -xzf "$tgz" -C "$tmpdir"
 
-    if [[ -x "$tmpdir/scripts/env-setup.sh" ]]; then
+    if [[ -f "$tmpdir/scripts/env-setup.sh" ]]; then
+        chmod +x "$tmpdir/scripts/env-setup.sh"
         (cd "$tmpdir/scripts" && ./env-setup.sh)
     else
         echo "Error: env-setup.sh not found in the API package."
@@ -296,6 +297,78 @@ fix_ownership() {
     [[ -f /usr/lib/libscanoss_encoder.so ]] && chown "$RUNTIME_USER:$RUNTIME_USER" /usr/lib/libscanoss_encoder.so
 }
 
+# ─── Decoration Services ────────────────────────────────────────────────────
+
+DECORATION_SERVICES=(dependencies components vulnerabilities cryptography geoprovenance licenses folder-hashing-api)
+
+install_decoration_service() {
+    local service="$1"
+    local version="latest"
+    local pkg_dir="$APP_DIR/$service/$version"
+
+    local tgz
+    tgz=$(find "$pkg_dir" -name "scanoss-${service}-api_linux-amd64_*.tgz" -o -name "scanoss-${service}_linux-amd64_*.tgz" 2>/dev/null | head -1)
+    if [[ -z "$tgz" ]]; then
+        echo "Error: No .tgz package found for $service in $pkg_dir"
+        echo "  Run 'Download components from SFTP' first."
+        return 1
+    fi
+
+    log "Installing $service from $tgz"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    tar -xzf "$tgz" -C "$tmpdir"
+
+    if [[ -f "$tmpdir/scripts/env-setup.sh" ]]; then
+        chmod +x "$tmpdir/scripts/env-setup.sh"
+        (cd "$tmpdir/scripts" && ./env-setup.sh)
+    else
+        echo "Error: env-setup.sh not found in the $service package."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    rm -rf "$tmpdir"
+}
+
+download_decoration_services() {
+    if ! command -v lftp &>/dev/null; then
+        echo "Error: lftp is not installed. Run option 2 (Install dependencies) first."
+        return 1
+    fi
+    load_sftp_creds || return 1
+
+    echo ""
+    echo "Downloading decoration services"
+    echo "────────────────────────────────"
+    for svc in "${DECORATION_SERVICES[@]}"; do
+        download_component "$svc" "latest"
+    done
+}
+
+install_decoration_select() {
+    echo ""
+    echo "Select decoration service to install:"
+    select svc in "All decoration services" "${DECORATION_SERVICES[@]}" "Back"; do
+        case "$svc" in
+            "All decoration services")
+                for s in "${DECORATION_SERVICES[@]}"; do
+                    install_decoration_service "$s"
+                done
+                break
+                ;;
+            "Back") break ;;
+            *)
+                if [[ -n "$svc" ]]; then
+                    install_decoration_service "$svc"
+                    break
+                else
+                    echo "Invalid option."
+                fi
+                ;;
+        esac
+    done
+}
+
 install_all() {
     echo ""
     echo "Installing all SCANOSS components"
@@ -308,16 +381,18 @@ install_all() {
     install_encoder
     fix_ownership
     echo ""
-    echo "All components installed. Run the test script to verify:"
+    echo "All core components installed. Run the test script to verify:"
     echo "  ./test.sh"
+    echo ""
+    echo "To install decoration services, use menu option 8."
 }
 
 install_select() {
     echo ""
     echo "Select component to install:"
-    select app in "All components" "engine" "ldb" "API" "encoder" "Back"; do
+    select app in "All core components" "engine" "ldb" "API" "encoder" "Back"; do
         case "$app" in
-            "All components") install_all; break ;;
+            "All core components") install_all; break ;;
             "engine") install_engine; break ;;
             "ldb") install_ldb; break ;;
             "API") install_api; break ;;
@@ -367,15 +442,17 @@ while true; do
     echo ""
     echo "Installation Menu"
     echo "─────────────────"
-    echo "1) Install everything (dependencies + download + install)"
+    echo "1) Install everything (dependencies + download + install core)"
     echo "2) Install system dependencies only"
     echo "3) Setup SFTP credentials"
-    echo "4) Download components from SFTP"
-    echo "5) Install components (from already downloaded files)"
+    echo "4) Download core components from SFTP"
+    echo "5) Install core components (from already downloaded files)"
     echo "6) Select versions (current: engine=$ENGINE_VERSION, ldb=$LDB_VERSION, api=$API_VERSION)"
-    echo "7) Quit"
+    echo "7) Download decoration services from SFTP"
+    echo "8) Install decoration services"
+    echo "9) Quit"
     echo ""
-    read -rp "Enter your choice [1-7]: " choice
+    read -rp "Enter your choice [1-9]: " choice
 
     case "$choice" in
         1)
@@ -391,7 +468,9 @@ while true; do
         4) download_all ;;
         5) install_select ;;
         6) select_versions ;;
-        7) echo "Exiting."; exit 0 ;;
+        7) download_decoration_services ;;
+        8) install_decoration_select ;;
+        9) echo "Exiting."; exit 0 ;;
         *) echo "Invalid option." ;;
     esac
 done

--- a/install/install-scanoss.sh
+++ b/install/install-scanoss.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+# Don't use set -e: we handle errors per function to avoid killing the whole
+# interactive menu when a single component fails.
 
 # Import configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -44,12 +45,12 @@ install_dependencies() {
 
     case "$OS" in
         Debian)
-            # Detect libsodium package name (varies by Debian version)
-            local libsodium_pkg="libsodium23"
-            local deb_version
-            deb_version=$(cat /etc/debian_version | cut -d. -f1)
-            if [[ "$deb_version" -ge 13 ]]; then
-                libsodium_pkg="libsodium26"
+            # Detect libsodium package name from available packages
+            local libsodium_pkg
+            libsodium_pkg=$(apt-cache search '^libsodium[0-9]' 2>/dev/null | awk '{print $1}' | head -1)
+            if [[ -z "$libsodium_pkg" ]]; then
+                libsodium_pkg="libsodium23"
+                log "Warning: could not detect libsodium package, falling back to $libsodium_pkg"
             fi
 
             local deb_packages=(coreutils unrar-free xz-utils p7zip-full "$libsodium_pkg" libgcrypt20-dev)
@@ -84,6 +85,12 @@ install_dependencies() {
 # ─── SFTP Setup ─────────────────────────────────────────────────────────────
 
 setup_sftp() {
+    # Check lftp is installed
+    if ! command -v lftp &>/dev/null; then
+        echo "Error: lftp is not installed. Run option 2 (Install dependencies) first."
+        return 1
+    fi
+
     echo ""
     echo "SFTP Credentials"
     echo "──────────────────"
@@ -105,7 +112,7 @@ setup_sftp() {
 
     # Test connection
     echo "Testing connection..."
-    if echo "ls" | lftp -u "$SFTP_USER","$SFTP_PASSWORD" -p "$SFTP_PORT" "sftp://$SFTP_HOST" 2>/dev/null; then
+    if lftp -u "$SFTP_USER","$SFTP_PASSWORD" -p "$SFTP_PORT" "sftp://$SFTP_HOST" -e "set sftp:auto-confirm yes; ls; exit" &>/dev/null; then
         echo "Connection successful."
     else
         echo "Error: Could not connect to SFTP server."
@@ -137,6 +144,11 @@ download_component() {
     local component="$1"
     local version="$2"
 
+    if ! command -v lftp &>/dev/null; then
+        echo "Error: lftp is not installed. Run option 2 (Install dependencies) first."
+        return 1
+    fi
+
     load_sftp_creds || return 1
 
     local remote_path="/binaries/$component/$version"
@@ -146,7 +158,7 @@ download_component() {
     mkdir -p "$local_path"
 
     lftp -u "$SFTP_USER","$SFTP_PASSWORD" -p "$SFTP_PORT" "sftp://$SFTP_HOST" -e \
-        "mirror -c -P 5 $remote_path $local_path; exit" 2>/dev/null
+        "set sftp:auto-confirm yes; mirror -c -P 5 $remote_path $local_path; exit" 2>/dev/null
 
     if [[ -d "$local_path" ]] && ls "$local_path"/* &>/dev/null; then
         log "Downloaded $component $version to $local_path"
@@ -288,6 +300,8 @@ install_all() {
     echo ""
     echo "Installing all SCANOSS components"
     echo "──────────────────────────────────"
+    create_scanoss_user
+    create_directories
     install_engine
     install_ldb
     install_api

--- a/install/install-scanoss.sh
+++ b/install/install-scanoss.sh
@@ -1,445 +1,383 @@
 #!/bin/bash
+set -e
 
-set -e # Exit immediately if a command exits with a non-zero status.
+# Import configuration
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
 
-# Import configuration file
-source ./config.sh
+# ─── OS Detection ───────────────────────────────────────────────────────────
 
-function detect_os_type() {
+detect_os() {
     if [ -f /etc/debian_version ]; then
         echo "Debian"
     elif [ -f /etc/redhat-release ] || [ -f /etc/centos-release ]; then
         echo "CentOS"
     else
-        echo "This operating system is not supported, refer to the document provided with this script for more details (page X)"
+        echo "Unsupported OS. Supported: Debian 11/12/13, CentOS/RHEL."
         exit 1
     fi
 }
 
-function install_dependencies {
-  log "Installing system dependencies..."
-  
-  # Define the list of dependencies to install
-  packages=(
-      gzip
-      tar
-      unzip
-      ruby
-      curl
-      lftp
-      jq
-      wget
-      sshpass
-  ) 
+# ─── User & Directory Setup ─────────────────────────────────────────────────
 
-  deb_packages=(
-      coreutils
-      unrar-free
-      xz-utils
-      p7zip-full
-      libsodium23
-      libgcrypt20-dev
-  )
-
-  rpm_packages=(
-      coreutils-common
-      xz
-      openssh-clients
-  )
-
-  case "$OS" in
-    "Debian")
-        echo "Installing Debian dependencies."
-
-        # Install the packages
-        echo "Installing packages..."
-        apt update && apt install -y "${packages[@]}" "${deb_packages[@]}"
-        ;;
-    "CentOS")
-        echo "Installing CentOS dependencies."
-        
-        # Install dependencies
-        yum update -y 
-        dnf install -y openssl
-
-        # Install the packages
-        echo "Installing packages..."
-        yum install -y "${packages[@]}" "${rpm_packages[@]}"
-
-        # Install Libsodium
-        yum groupinstall 'Development Tools' -y
-
-        # Build Libsodium
-        curl -O https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable.tar.gz
-        tar -xzvf libsodium-1.0.18-stable.tar.gz
-        cd libsodium-stable
-        ./configure
-        make && make check
-        make install
-        ;;
-    esac
+create_scanoss_user() {
+    if getent passwd "$RUNTIME_USER" > /dev/null 2>&1; then
+        log "User $RUNTIME_USER already exists."
+    else
+        log "Creating system user: $RUNTIME_USER"
+        useradd --system --shell /bin/false "$RUNTIME_USER"
+    fi
 }
 
-function setup_sftp {
-  # Ask for SFTP credentials
-  echo "Please enter your SFTP Credentials below"
-  read -p "Enter your username: " SCANOSS_SFTP_USER
-  read -s -p "Enter your password: " SCANOSS_SFTP_PASSWORD
-  echo ""
-
-  if [[ -z "$SCANOSS_SFTP_USER" || -z "$SCANOSS_SFTP_PASSWORD" ]]; then
-    echo "Error: username or password is empty."
-    exit 1
-  fi
-
-  echo SCANOSS_LOGIN="${SCANOSS_SFTP_USER}:${SCANOSS_SFTP_PASSWORD}" > ~/.scanoss_login
-  chmod 600 ~/.scanoss_login
-  
-  echo "$SCANOSS_SFTP_USER" > ~/.ssh_user
-  chmod 600 ~/.ssh_user
-
-  echo "$SCANOSS_SFTP_PASSWORD" > ~/.sshpass
-  chmod 600 ~/.sshpass
-
-  echo "ls" | sshpass -f ~/.sshpass sftp -o "StrictHostKeyChecking=no" -P 49322  "$SCANOSS_SFTP_USER"@sftp.scanoss.com 
-
-  echo "Connection succesful!"
-
+create_directories() {
+    log "Creating directories..."
+    mkdir -p "$APP_DIR" "$LDB_LOCATION" "/var/log/$APP_NAME" "/usr/local/etc/$APP_NAME"
+    chown -R "$RUNTIME_USER:$RUNTIME_USER" "/var/log/$APP_NAME" "/usr/local/etc/$APP_NAME"
 }
 
-function download_application {
-  log "Downloading Application to $APP_DIR..."
-  # Add commands to install application here
-  read -p "Download SCANOSS Application files (y/abort) [abort]? " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]] ; then
-    echo "Setting up application download..."
-  else
-    echo "Stopping."
-    exit 1
-  fi
+# ─── Dependencies ───────────────────────────────────────────────────────────
 
-  read -p "Enter the installation directory location (default: $APP_DIR): " DOWNLOAD_LOCATION
-  APP_DIR=${DOWNLOAD_LOCATION:-$APP_DIR}
+install_dependencies() {
+    log "Installing system dependencies..."
 
-  echo "Select the source for the installation of SCANOSS Application files:"
+    local common_packages=(gzip tar unzip curl lftp jq wget)
 
-  select download_source in "SCANOSS (LFTP)" "Other"
-  do
-    case $download_source in 
-        "SCANOSS (LFTP)")
-
-            lftp -u "$(cat ~/.ssh_user)":"$(cat ~/.sshpass)" -e "mirror -c -e -P 10  /binaries/ $APP_DIR; exit" sftp://sftp.scanoss.com:49322
-
-            break
-    ;;
-        "Other")
-
-            echo "Refer to the document provided with this script (section X)"
-        
-            break
-    ;;
-
-    esac
-  done
-}
-
-function install_application {
-  log "Installing $APP_NAME to $APP_DIR..."
-  # Add commands to install application here
-
-  install_application_dependencies() {
-        log "Installing application dependencies"
-
-        local dependency_package_path="$APP_DIR/app_dependencies/"
-        if [ $OS = "CentOS" ]; then
-            if dnf list installed | grep -q "libsodium"; then
-                log "libsodium is already installed via package manager"
-            else
-                tar -xzvf "$dependency_package_path/centos/libsodium"*"tar.gz"
-                cd "$dependency_package_path/centos/libsodium-stable"
-                ./configure
-                make && make check
-                make install
-                dnf -y install "$APP_DIR/dependencies/libsodium/"* 
+    case "$OS" in
+        Debian)
+            # Detect libsodium package name (varies by Debian version)
+            local libsodium_pkg="libsodium23"
+            local deb_version
+            deb_version=$(cat /etc/debian_version | cut -d. -f1)
+            if [[ "$deb_version" -ge 13 ]]; then
+                libsodium_pkg="libsodium26"
             fi
-        fi
-        
-        log "Finished installing dependencies"
 
-        echo "Finished installing dependencies"
-    
-    }
+            local deb_packages=(coreutils unrar-free xz-utils p7zip-full "$libsodium_pkg" libgcrypt20-dev)
 
-  installDpkg() {
-      local component=$1
+            apt-get update -qq
+            apt-get install -y -qq "${common_packages[@]}" "${deb_packages[@]}"
+            ;;
+        CentOS)
+            local rpm_packages=(coreutils-common xz openssh-clients openssl)
 
-      ret=$?
-      if [ $ret -ne 0 ] ; then
-          echo "Failed to find an installation package for $component in $APP_DIR"
-          return 1
-      fi
+            dnf install -y "${common_packages[@]}" "${rpm_packages[@]}"
 
-      log "Installing SCANOSS $component"
-
-      # Special case, the engine package is called 'scanoss'
-      local package_path="$APP_DIR/$component/$VERSION/$component_*_amd64.deb"
-      if [ $component = "engine" ]; then
-          package_path="$APP_DIR/$component/$VERSION/scanoss_*_amd64.deb"
-      fi
-      echo $package_path
-
-      dpkg -i $package_path
-  }
-
-  installRpm() {
-      local component=$1
-
-      ret=$?
-      if [ $ret -ne 0 ] ; then
-          echo "Failed to find an installation package for $component in $APP_DIR"
-          return 1
-      fi
-
-      log "Installing SCANOSS $component"
-
-      # Special case, the engine package is called 'scanoss'
-      local package_path="$APP_DIR/$component/$VERSION/scanoss*.rpm"
-      if [ $component = "engine" ]; then
-          package_path="$APP_DIR/$component/$VERSION/scanoss*.rpm"
-      fi
-      echo $package_path
-      
-      dnf -y install "$package_path"
-  }
-
-  # Install API
-
-  installApi(){
-
-    local tar_file_path="$APP_DIR/api/$VERSION/scanoss-go_linux-amd64_*.tgz"
-
-    echo 'Extracting ' $tar_file_path
-    mkdir -p $APP_DIR/tmp
-    tar -xzvf $tar_file_path -C "$APP_DIR/tmp/"
-
-    log "Installing SCANOSS API"
-    
-    chmod +x $APP_DIR/tmp/scripts/env-setup.sh
-    (cd $APP_DIR/tmp/scripts ; ./env-setup.sh )
-
-  }
-
-  installEncoderLib() {
-
-    log 'Installing SCANOSS Encoder Library'
-    # Find the tar.gz file in the version directory
-    local tar_file=$(find "$APP_DIR/scanoss-encoder/$VERSION" -maxdepth 1 -name "*.tar.gz" | head -n 1)
-    
-    if [ -n "$tar_file" ]; then
-        log "Found tar.gz file: $tar_file. Extracting..."
-        tar -xzf "$tar_file" -C "$APP_DIR/scanoss-encoder/$VERSION"
-    else
-        log "No tar.gz file found."
-    fi
-    
-    # Copy the library file to the appropriate location
-    if [ -f "$APP_DIR/scanoss-encoder/$VERSION/libscanoss_encoder.so" ]; then
-        cp "$APP_DIR/scanoss-encoder/$VERSION/libscanoss_encoder.so" /usr/lib/libscanoss_encoder.so
-        ldconfig
-        echo "scanoss-encoder installed succesfully!"
-    else
-        log "Library file libscanoss_encoder.so not found."
-        echo "libscanoss_encoder.so not found."
-    fi
-  }
-
-  correctOwnership() {
-
-    log 'Updating ownership for SCANOSS applications and directories'
-    chown -R $RUNTIME_USER:$RUNTIME_USER /var/log/$APP_NAME
-    chown -R $RUNTIME_USER:$RUNTIME_USER /usr/local/etc/$APP_NAME
-    chown -R $RUNTIME_USER:$RUNTIME_USER /bin/scanoss
-    chown -R $RUNTIME_USER:$RUNTIME_USER /bin/ldb
-    chown -R $RUNTIME_USER:$RUNTIME_USER /usr/lib/libscanoss_encoder.so
-
-  }
-
-  case "$OS" in
-    "Debian")
-    select application in "Install all applications and dependencies" "Install dependencies" "engine" "ldb" "API" "encoder" "Quit"
-        do
-            case $application in 
-                "Install all applications and dependencies")
-                    install_application_dependencies
-                    installDpkg "engine"
-                    installDpkg "ldb"
-                    installApi
-                    installEncoderLib
-                    correctOwnership
-                    ;;
-                "Install dependencies")
-                    install_application_dependencies 
-                    ;;
-                "engine")
-                    installDpkg "engine"
-                    ;;
-                "ldb")
-                    installDpkg "ldb"
-                    ;;
-                "API")
-                    installApi
-                    ;;
-                "scanoss-encoder")
-                    installEncoderLib
-                    ;;
-                "Quit")
-                    echo "Exiting..."
-                    break
-                    ;;
-                *)
-                    echo "Invalid option"
-                    ;;
-            esac
-        done
-    ;;
-    "CentOS")
-      select application in "Install all applications and dependencies" "Install dependencies" "engine" "ldb" "API" "scanoss-encoder" "Quit"
-        do
-            case $application in 
-                "Install all applications and application dependencies")
-                    install_application_dependencies
-                    installRpm "engine"
-                    installRpm "ldb"
-                    installApi
-                    installEncoderLib
-                    correctOwnership
-                    ;;
-                "Install dependencies")
-                    install_application_dependencies 
-                    ;;
-                "engine")
-                    installRpm "engine"
-                    ;;
-                "ldb")
-                    installRpm "ldb"
-                    ;;
-                "API")
-                    installApi
-                    ;;
-                "scanoss-encoder")
-                    installEncoderLib
-                    ;;
-                "Quit")
-                    echo "Exiting..."
-                    break
-                    ;;
-                *)
-                    echo "Invalid option"
-                    ;;
-            esac
-        done
-      ;;
+            # Build libsodium from source if not installed
+            if ! ldconfig -p | grep -q libsodium; then
+                log "Building libsodium from source..."
+                dnf groupinstall -y 'Development Tools'
+                local tmpdir
+                tmpdir=$(mktemp -d)
+                curl -sL -o "$tmpdir/libsodium.tar.gz" \
+                    https://download.libsodium.org/libsodium/releases/libsodium-1.0.20-stable.tar.gz
+                tar -xzf "$tmpdir/libsodium.tar.gz" -C "$tmpdir"
+                (cd "$tmpdir/libsodium-stable" && ./configure && make -j"$(nproc)" && make install)
+                ldconfig
+                rm -rf "$tmpdir"
+            fi
+            ;;
     esac
 
+    log "Dependencies installed."
 }
 
-function create_scanoss_user {
+# ─── SFTP Setup ─────────────────────────────────────────────────────────────
 
-    # Makes sure the scanoss user exists
-    if ! getent passwd $RUNTIME_USER > /dev/null ; then
-    echo "Runtime user does not exist: $RUNTIME_USER"
-    read -p "Do you want to create the user $RUNTIME_USER (y/abort) [abort]? " -n 1 -r
-    echo
-    if [[ $REPLY =~ ^[Yy]$ ]] ; then
-        case "$OS" in
-            "Debian")
-            useradd --system $RUNTIME_USER
-            ;;
-            "CentOS")
-            adduser --system $RUNTIME_USER
-            ;;
-            esac
-        
-        echo "User $RUNTIME_USER created successfully"
-    else
-        echo "Stopping."
+setup_sftp() {
+    echo ""
+    echo "SFTP Credentials"
+    echo "──────────────────"
+
+    read -rp "SFTP host [$SFTP_HOST]: " input_host
+    SFTP_HOST="${input_host:-$SFTP_HOST}"
+
+    read -rp "SFTP port [$SFTP_PORT]: " input_port
+    SFTP_PORT="${input_port:-$SFTP_PORT}"
+
+    read -rp "SFTP username: " SFTP_USER
+    read -rsp "SFTP password: " SFTP_PASSWORD
+    echo ""
+
+    if [[ -z "$SFTP_USER" || -z "$SFTP_PASSWORD" ]]; then
+        echo "Error: username and password are required."
         exit 1
     fi
 
-fi
+    # Test connection
+    echo "Testing connection..."
+    if echo "ls" | lftp -u "$SFTP_USER","$SFTP_PASSWORD" -p "$SFTP_PORT" "sftp://$SFTP_HOST" 2>/dev/null; then
+        echo "Connection successful."
+    else
+        echo "Error: Could not connect to SFTP server."
+        exit 1
+    fi
+
+    # Save credentials for later use
+    echo "SFTP_USER=$SFTP_USER" > ~/.scanoss_sftp
+    echo "SFTP_PASSWORD=$SFTP_PASSWORD" >> ~/.scanoss_sftp
+    echo "SFTP_HOST=$SFTP_HOST" >> ~/.scanoss_sftp
+    echo "SFTP_PORT=$SFTP_PORT" >> ~/.scanoss_sftp
+    chmod 600 ~/.scanoss_sftp
+
+    log "SFTP credentials saved to ~/.scanoss_sftp"
 }
 
-function create_ldb_directory {
-    if [ ! -d "$LDB_LOCATION" ]; then
-        echo "Creating LDB directory: $LDB_LOCATION"
-        mkdir -p "$LDB_LOCATION"
+load_sftp_creds() {
+    if [[ -f ~/.scanoss_sftp ]]; then
+        source ~/.scanoss_sftp
     else
-        echo "LDB directory already exists: $LDB_LOCATION"
+        echo "No saved SFTP credentials found. Run 'Setup SFTP Credentials' first."
+        return 1
     fi
 }
 
-# Main script
-echo "Starting $APP_NAME installation script..."
-log "Starting $APP_NAME installation script..."
+# ─── Download ───────────────────────────────────────────────────────────────
 
-# Make sure we're running as root
-if [ "$(id -u)" != "0" ]; then
-  echo "This script must be run as root."
-  exit 1
+download_component() {
+    local component="$1"
+    local version="$2"
+
+    load_sftp_creds || return 1
+
+    local remote_path="/binaries/$component/$version"
+    local local_path="$APP_DIR/$component/$version"
+
+    echo "Downloading $component ($version) from SFTP..."
+    mkdir -p "$local_path"
+
+    lftp -u "$SFTP_USER","$SFTP_PASSWORD" -p "$SFTP_PORT" "sftp://$SFTP_HOST" -e \
+        "mirror -c -P 5 $remote_path $local_path; exit" 2>/dev/null
+
+    if [[ -d "$local_path" ]] && ls "$local_path"/* &>/dev/null; then
+        log "Downloaded $component $version to $local_path"
+        echo "$component $version downloaded successfully."
+    else
+        echo "Error: Download of $component $version failed or directory is empty."
+        return 1
+    fi
+}
+
+download_all() {
+    echo ""
+    echo "Downloading SCANOSS components"
+    echo "──────────────────────────────"
+    echo "Versions: engine=$ENGINE_VERSION, ldb=$LDB_VERSION, api=$API_VERSION, encoder=$ENCODER_VERSION"
+    echo ""
+
+    download_component "engine" "$ENGINE_VERSION"
+    download_component "ldb" "$LDB_VERSION"
+    download_component "api" "$API_VERSION"
+    download_component "scanoss-encoder" "$ENCODER_VERSION"
+}
+
+# ─── Install ────────────────────────────────────────────────────────────────
+
+install_engine() {
+    local version="${ENGINE_VERSION}"
+    local pkg_dir="$APP_DIR/engine/$version"
+
+    case "$OS" in
+        Debian)
+            local deb
+            deb=$(find "$pkg_dir" -name "scanoss_*_amd64.deb" | head -1)
+            if [[ -z "$deb" ]]; then
+                echo "Error: No engine .deb package found in $pkg_dir"
+                return 1
+            fi
+            log "Installing engine from $deb"
+            dpkg -i "$deb"
+            ;;
+        CentOS)
+            local rpm
+            rpm=$(find "$pkg_dir" -name "scanoss*.rpm" | head -1)
+            if [[ -z "$rpm" ]]; then
+                echo "Error: No engine .rpm package found in $pkg_dir"
+                return 1
+            fi
+            log "Installing engine from $rpm"
+            dnf -y install "$rpm"
+            ;;
+    esac
+}
+
+install_ldb() {
+    local version="${LDB_VERSION}"
+    local pkg_dir="$APP_DIR/ldb/$version"
+
+    case "$OS" in
+        Debian)
+            local deb
+            deb=$(find "$pkg_dir" -name "ldb_*_amd64.deb" | head -1)
+            if [[ -z "$deb" ]]; then
+                echo "Error: No ldb .deb package found in $pkg_dir"
+                return 1
+            fi
+            log "Installing ldb from $deb"
+            dpkg -i "$deb"
+            ;;
+        CentOS)
+            local rpm
+            rpm=$(find "$pkg_dir" -name "ldb*.rpm" | head -1)
+            if [[ -z "$rpm" ]]; then
+                echo "Error: No ldb .rpm package found in $pkg_dir"
+                return 1
+            fi
+            log "Installing ldb from $rpm"
+            dnf -y install "$rpm"
+            ;;
+    esac
+}
+
+install_api() {
+    local version="${API_VERSION}"
+    local pkg_dir="$APP_DIR/api/$version"
+
+    local tgz
+    tgz=$(find "$pkg_dir" -name "scanoss-go_linux-amd64_*.tgz" -o -name "scanoss-go-api_*.tgz" | head -1)
+    if [[ -z "$tgz" ]]; then
+        echo "Error: No API .tgz package found in $pkg_dir"
+        return 1
+    fi
+
+    log "Installing API from $tgz"
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    tar -xzf "$tgz" -C "$tmpdir"
+
+    if [[ -x "$tmpdir/scripts/env-setup.sh" ]]; then
+        (cd "$tmpdir/scripts" && ./env-setup.sh)
+    else
+        echo "Error: env-setup.sh not found in the API package."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    rm -rf "$tmpdir"
+}
+
+install_encoder() {
+    local version="${ENCODER_VERSION}"
+    local pkg_dir="$APP_DIR/scanoss-encoder/$version"
+
+    local tgz
+    tgz=$(find "$pkg_dir" -maxdepth 1 -name "*.tar.gz" | head -1)
+    if [[ -n "$tgz" ]]; then
+        log "Extracting encoder from $tgz"
+        tar -xzf "$tgz" -C "$pkg_dir"
+    fi
+
+    if [[ -f "$pkg_dir/libscanoss_encoder.so" ]]; then
+        cp "$pkg_dir/libscanoss_encoder.so" /usr/lib/libscanoss_encoder.so
+        ldconfig
+        log "scanoss-encoder installed."
+    else
+        echo "Warning: libscanoss_encoder.so not found in $pkg_dir"
+        return 1
+    fi
+}
+
+fix_ownership() {
+    log "Setting ownership for SCANOSS directories..."
+    chown -R "$RUNTIME_USER:$RUNTIME_USER" "/var/log/$APP_NAME" 2>/dev/null || true
+    chown -R "$RUNTIME_USER:$RUNTIME_USER" "/usr/local/etc/$APP_NAME" 2>/dev/null || true
+    [[ -d /bin/scanoss ]] && chown -R "$RUNTIME_USER:$RUNTIME_USER" /bin/scanoss
+    [[ -d /bin/ldb ]] && chown -R "$RUNTIME_USER:$RUNTIME_USER" /bin/ldb
+    [[ -f /usr/lib/libscanoss_encoder.so ]] && chown "$RUNTIME_USER:$RUNTIME_USER" /usr/lib/libscanoss_encoder.so
+}
+
+install_all() {
+    echo ""
+    echo "Installing all SCANOSS components"
+    echo "──────────────────────────────────"
+    install_engine
+    install_ldb
+    install_api
+    install_encoder
+    fix_ownership
+    echo ""
+    echo "All components installed. Run the test script to verify:"
+    echo "  ./test.sh"
+}
+
+install_select() {
+    echo ""
+    echo "Select component to install:"
+    select app in "All components" "engine" "ldb" "API" "encoder" "Back"; do
+        case "$app" in
+            "All components") install_all; break ;;
+            "engine") install_engine; break ;;
+            "ldb") install_ldb; break ;;
+            "API") install_api; break ;;
+            "encoder") install_encoder; break ;;
+            "Back") break ;;
+            *) echo "Invalid option." ;;
+        esac
+    done
+}
+
+# ─── Version Selection ──────────────────────────────────────────────────────
+
+select_versions() {
+    echo ""
+    echo "Current versions: engine=$ENGINE_VERSION, ldb=$LDB_VERSION, api=$API_VERSION, encoder=$ENCODER_VERSION"
+    echo "(\"latest\" uses the most recent release on SFTP)"
+    echo ""
+    read -rp "Engine version [$ENGINE_VERSION]: " v
+    ENGINE_VERSION="${v:-$ENGINE_VERSION}"
+    read -rp "LDB version [$LDB_VERSION]: " v
+    LDB_VERSION="${v:-$LDB_VERSION}"
+    read -rp "API version [$API_VERSION]: " v
+    API_VERSION="${v:-$API_VERSION}"
+    read -rp "Encoder version [$ENCODER_VERSION]: " v
+    ENCODER_VERSION="${v:-$ENCODER_VERSION}"
+    echo "Versions set: engine=$ENGINE_VERSION, ldb=$LDB_VERSION, api=$API_VERSION, encoder=$ENCODER_VERSION"
+}
+
+# ─── Main ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "SCANOSS On-Premise Installer"
+echo "════════════════════════════"
+echo ""
+
+if [[ "$(id -u)" != "0" ]]; then
+    echo "This script must be run as root."
+    exit 1
 fi
 
-# Make sure the application directory exists, otherwise it creates it
-if [ ! -d "$APP_DIR" ]; then
-    echo "Creating application directory: $APP_DIR"
-    mkdir -p "$APP_DIR"
-fi
+OS=$(detect_os)
+log "Detected OS: $OS"
 
-# Detect operating system automatically
-OS=$(detect_os_type)
+mkdir -p "$APP_DIR"
 
 while true; do
-    echo
-    echo "SCANOSS Installation Menu"
-    echo "------------------------"
-    echo "1) Install everything"
-    echo "2) Install Dependencies"
-    echo "3) Setup SFTP Credentials"
-    echo "4) Download Application"
-    echo "5) Install Application"
-    echo "6) Quit"
-    echo
-    read -p "Enter your choice [1-6]: " choice
+    echo ""
+    echo "Installation Menu"
+    echo "─────────────────"
+    echo "1) Install everything (dependencies + download + install)"
+    echo "2) Install system dependencies only"
+    echo "3) Setup SFTP credentials"
+    echo "4) Download components from SFTP"
+    echo "5) Install components (from already downloaded files)"
+    echo "6) Select versions (current: engine=$ENGINE_VERSION, ldb=$LDB_VERSION, api=$API_VERSION)"
+    echo "7) Quit"
+    echo ""
+    read -rp "Enter your choice [1-7]: " choice
 
-    case $choice in
+    case "$choice" in
         1)
             create_scanoss_user
-            create_ldb_directory
+            create_directories
             install_dependencies
             setup_sftp
-            download_application
-            install_application
+            download_all
+            install_all
             ;;
-        2)
-            install_dependencies
-            ;;    
-        3)
-            setup_sftp
-            ;;
-        4)
-            download_application
-            ;;
-        5)
-            create_scanoss_user
-            create_ldb_directory
-            install_application
-            ;;
-        6)
-            echo "Exiting script..."
-            exit 0
-            ;;
-        *)
-            echo "Invalid option. Please enter a number between 1-4."
-            ;;
+        2) install_dependencies ;;
+        3) setup_sftp ;;
+        4) download_all ;;
+        5) install_select ;;
+        6) select_versions ;;
+        7) echo "Exiting."; exit 0 ;;
+        *) echo "Invalid option." ;;
     esac
 done


### PR DESCRIPTION
## Summary

Rewrites install-scanoss.sh and config.sh. Tested end-to-end on uat01 (Debian 13).

### Core changes
- Downloads only the requested version from SFTP (default: latest) instead of mirroring the entire /binaries/ directory
- Auto-detects libsodium package via apt-cache (works on Debian 11/12/13)
- Fixes CentOS "Install all" (typo in case statement meant it never matched)
- Adds version selection menu (option 6)
- Adds lftp host key auto-confirm and dependency check before SFTP operations
- Removes set -e, errors handled per component so one failure does not kill the whole menu
- install_all creates scanoss user and directories automatically

### Decoration services (new)
- Menu option 7: download all decoration services from SFTP
- Menu option 8: install decoration services (all or individual)
- Supported: dependencies, components, vulnerabilities, cryptography, geoprovenance, licenses, folder-hashing-api

### SFTP cron (s3, separate from this PR)
check_releases.sh updated to pull all 11 packages (core + decoration services). GitHub token configured for private repos.

### Test results on uat01 (Debian 13)
- Dependencies install: OK
- SFTP connection (SL00): OK
- Core download (engine, ldb, api, encoder, 2 seconds): OK
- Core install (engine 5.4.25, ldb 4.1.11, api 1.6.8, encoder 1.3.2): OK
- Decoration download (7 services): OK
- Decoration install (7/7 binaries + systemd units): OK

### Known issue (upstream)
geoprovenance env-setup.sh has a bug: config download URL is empty, curl fails. This is in the geoprovenance repo, not this PR.