### PR TITLE
Add hfh download mode for single-zip KB snapshots

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -35,7 +35,7 @@
 2. Add execution permissions to the installation scripts: ```cd on-premise/install/ && chmod +x *.sh```
 3. Run the install-scanoss.sh script: ```sudo ./install-scanoss.sh```
 4. Choose option 1) Install everything
-5. Run the kb-download.sh script: ```./kb-download.sh``` and choose what to download (full KB, an update, the test KB, or a SQLite KB snapshot). If you downloaded a KB update, run the `ldb-import.sh` script included in the download folder to import it into your local LDB.
+5. Run the kb-download.sh script: ```./kb-download.sh``` and choose what to download (full KB, an update, the test KB, a SQLite KB snapshot, or an HFH KB snapshot). If you downloaded a KB update, run the `ldb-import.sh` script included in the download folder to import it into your local LDB.
 6. Installation finished!
 
 ## Introduction
@@ -77,7 +77,7 @@ The following is recommended for running the SCANOSS Applications and SCANOSS Te
 ## Repository Contents
 
 - [install-scanoss.sh](./install-scanoss.sh): bash script for installing SCANOSS (SFTP user setup creation, dependencies installation and application download/install)
-- [kb-download.sh](./kb-download.sh): bash script for downloading the full KB, KB updates, the test KB, or a SQLite KB snapshot from the SCANOSS SFTP server. KB update downloads ship with an `ldb-import.sh` helper that imports the update into your local LDB.
+- [kb-download.sh](./kb-download.sh): bash script for downloading the full KB, KB updates, the test KB, a SQLite KB snapshot, or an HFH KB snapshot from the SCANOSS SFTP server. KB update downloads ship with an `ldb-import.sh` helper that imports the update into your local LDB.
 - [test.sh](./test.sh): bash script for verifying the correct installation of SCANOSS and the SCANOSS KB
 - [resources](/resources): directory containing files for testing the installation of SCANOSS and the SCANOSS KB
 - [config.sh](./config.sh): configuration file
@@ -121,7 +121,7 @@ After finishing the installation run ```sudo systemctl start scanoss-go-api.serv
 
 ### Knowledge Base Download (kb-download.sh)
 
-The `kb-download.sh` script provides a unified way to download the full KB, a KB update, the test KB, or a SQLite KB snapshot directly from the SCANOSS SFTP server. It connects to the server, lists all available versions, lets you choose which one to download, and checks for sufficient disk space before starting. For updates, a separate import script (`ldb-import.sh`) included in the downloaded folder handles importing into your local LDB.
+The `kb-download.sh` script provides a unified way to download the full KB, a KB update, the test KB, a SQLite KB snapshot, or an HFH KB snapshot directly from the SCANOSS SFTP server. It connects to the server, lists all available versions, lets you choose which one to download, and checks for sufficient disk space before starting. For updates, a separate import script (`ldb-import.sh`) included in the downloaded folder handles importing into your local LDB.
 
 The **test KB** is a small, pre-built LDB used to verify that your installation is working before loading the full production KB.
 
@@ -163,7 +163,7 @@ All connection details, paths, and the download mode can be passed as arguments 
 
 | Flag | Description |
 |------|-------------|
-| `-m` | Download mode: `full` (full KB), `update` (KB update), `test` (test KB), or `sqlite` (SQLite KB snapshot) |
+| `-m` | Download mode: `full` (full KB), `update` (KB update), `test` (test KB), `sqlite` (SQLite KB snapshot), or `hfh` (HFH KB snapshot) |
 | `-h` | SFTP host |
 | `-P` | SFTP port |
 | `-u` | SFTP username |
@@ -176,10 +176,10 @@ All connection details, paths, and the download mode can be passed as arguments 
 
 | Flag | Description |
 |------|-------------|
-| `-V` | KB version (full/update/sqlite mode); default: latest from `LATEST.txt` on the server |
+| `-V` | KB version (full/update/sqlite/hfh mode); default: latest from `LATEST.txt` on the server |
 | `-o` | Destination path. Test mode: test-KB destination. Full mode: `oss` folder destination. (default: `/var/lib/ldb/oss`) |
 | `-r` | Full mode only: destination for non-oss items (default: `/tmp/scanoss_kb_full_<version>`) |
-| `-D` | Update / sqlite mode: download base directory. Final path is `<D>/<version>`. Defaults: `/tmp/scanoss_kb_update` for update, current directory for sqlite |
+| `-D` | Update / sqlite / hfh mode: download base directory. Final path is `<D>/<version>` for update/sqlite and `<D>/<version>.zip` for hfh. Defaults: `/tmp/scanoss_kb_update` for update, current directory for sqlite and hfh |
 
 **Non-interactive flags**
 
@@ -214,6 +214,10 @@ Any options not provided on the command line will be prompted interactively, unl
 ./kb-download.sh -y -m sqlite -D /opt/scanoss/sqlite \
     -h sftp.test.xyz -P 12345 -u USER21 -p mypassword
 
+# HFH KB (single .zip; lands at ./<version>.zip):
+./kb-download.sh -y -m hfh \
+    -h sftp.test.xyz -P 12345 -u USER21 -p mypassword
+
 # Test KB:
 ./kb-download.sh -y -m test -h sftp.test.xyz -P 12345 -u USER21 -p mypassword
 ```
@@ -221,15 +225,16 @@ Any options not provided on the command line will be prompted interactively, unl
 #### How it Works
 
 1. **Connection**: the script prompts for (or reads from arguments) the SFTP host, port, username, and password
-2. **Mode selection**: you choose between downloading the full KB, a KB update, the test KB, or a SQLite KB snapshot
-3. **Version discovery** (full/update/sqlite only): it connects to the SFTP server and lists all available versions of the chosen type, marking which one is the latest. Test KB has no versions — there is only one current test KB on the server.
-4. **Selection** (full/update/sqlite only): you choose which version to download (defaults to the latest)
-5. **Disk space check**: the script fetches the metadata and verifies there is enough free disk space before downloading. If not enough is available, you are warned and asked to confirm before continuing.
+2. **Mode selection**: you choose between downloading the full KB, a KB update, the test KB, a SQLite KB snapshot, or an HFH KB snapshot
+3. **Version discovery** (full/update/sqlite/hfh only): it connects to the SFTP server and lists all available versions of the chosen type, marking which one is the latest. Test KB has no versions — there is only one current test KB on the server.
+4. **Selection** (full/update/sqlite/hfh only): you choose which version to download (defaults to the latest)
+5. **Disk space check**: the script fetches the metadata and verifies there is enough free disk space before downloading. If not enough is available, you are warned and asked to confirm before continuing. (For HFH the size comes from `ls -l` on the remote `.zip` rather than `metadata.json`.)
 6. **Download**:
    - **For full KB**: the download is split between two destinations. The `oss` folder (the main LDB data) goes to its own destination (default: `/var/lib/ldb/oss`), and all remaining files and folders go to a separate directory (default: `/tmp/scanoss_kb_full_<version>`). Both destinations can be changed when prompted.
    - **For updates**: the whole update folder is downloaded to a single directory (default: `/tmp/scanoss_kb_update/<version>`).
    - **For test KB**: the test KB's `oss` folder is downloaded to a single destination (default: `/var/lib/ldb/oss`). This will populate your LDB with the test data for verification.
    - **For SQLite KB**: the whole version folder is downloaded to `<base>/<version>` (default base: the current working directory). The folder contains one or more `.sqlite` files plus a `metadata.json`. The script downloads every file you have access to in that folder — different users may see different sets of `.sqlite` files depending on their SFTP permissions.
+   - **For HFH KB**: a single `<version>.zip` archive is downloaded to `<base>/<version>.zip` (default base: the current working directory). With lftp the file is fetched in parallel chunks (`pget -n <threads>`); with sftp it's a single-stream `get` with the live progress poller. The script does not extract the archive — leave that to your downstream tooling.
 7. **Import (updates only)**: after downloading an update, run the `ldb-import.sh` script included in the downloaded folder
 
 #### Example Sessions
@@ -246,8 +251,9 @@ What do you want to download?
   2) KB update
   3) Test KB
   4) SQLite KB
+  5) HFH KB
 
-Select [1-4]: 2
+Select [1-5]: 2
 
 SFTP host: sftp.test.xyz
 SFTP port: 12345
@@ -398,6 +404,47 @@ Finished downloading sqlite KB.
 ```
 
 The downloaded folder contains all `.sqlite` files the SFTP user has access to (plus `metadata.json`). Different users may see different sets of files depending on their permissions.
+
+##### HFH KB
+
+```
+./kb-download.sh -m hfh -h sftp.test.xyz -P 12345 -u USER21
+
+SCANOSS Knowledge Base Download
+================================
+Using lftp for downloads (parallel, resumable).
+
+SFTP password:
+
+Fetching available hfh KB versions...
+
+Available hfh KB versions:
+-------------------
+  1) 26.06  (latest)
+-------------------
+
+Select a hfh KB version to download [1-1] (default: 1):
+
+Selected hfh KB: 26.06
+
+Download directory [.]:
+
+Fetching hfh KB file size...
+Hfh KB size: 35G
+Free space:  1.7T (on /dev/sda1)
+Disk space OK.
+
+lftp parallel threads [25]:
+
+Download hfh KB 26.06 to ./26.06.zip? [Y/n]
+Downloading kb/hfh/26.06.zip with lftp (25 parallel chunks, resumable)...
+
+Hfh KB downloaded to ./26.06.zip
+
+Finished downloading hfh KB.
+```
+
+HFH ships as a single `<version>.zip` archive (no `metadata.json`); the disk-space check reads the file size from the remote `ls -l` output. The script does not extract the archive — that's left to downstream tooling.
 
 #### Verifying a KB Update
 

--- a/install/kb-download.sh
+++ b/install/kb-download.sh
@@ -26,8 +26,9 @@ REMOTE_PATH_FULL="kb/full"
 REMOTE_PATH_UPDATE="kb/update"
 REMOTE_PATH_TEST="kb/test/oss"
 REMOTE_PATH_SQLITE="kb/sqlite"
+REMOTE_PATH_HFH="kb/hfh"
 
-MODE=""            # "full", "update", "test", or "sqlite"
+MODE=""            # "full", "update", "test", "sqlite", or "hfh"
 DOWNLOAD_TOOL=""   # set during init: "lftp" or "sftp"
 SFTP_USER=""
 SFTP_PASS=""
@@ -80,7 +81,7 @@ usage() {
     echo "          [-D path] [-y] [-f] [-C]"
     echo
     echo "Connection / mode options:"
-    echo "  -m    Download mode: full, update, test, or sqlite"
+    echo "  -m    Download mode: full, update, test, sqlite, or hfh"
     echo "  -h    SFTP host"
     echo "  -P    SFTP port"
     echo "  -u    SFTP username"
@@ -92,15 +93,15 @@ usage() {
     echo "        fast links carrying already-dense data (hashes, indexes)."
     echo
     echo "Path / version overrides (skip the matching interactive prompt):"
-    echo "  -V    KB version (full/update/sqlite mode); default: latest from LATEST.txt"
+    echo "  -V    KB version (full/update/sqlite/hfh mode); default: latest from LATEST.txt"
     echo "  -o    Destination path:"
     echo "          test mode -> test-KB destination (default: /var/lib/ldb/oss)"
     echo "          full mode -> 'oss' folder destination (default: /var/lib/ldb/oss)"
     echo "  -r    full mode: destination for non-oss items"
     echo "        (default: /tmp/scanoss_kb_full_<version>)"
-    echo "  -D    update/sqlite mode: download base directory"
-    echo "        (default: /tmp/scanoss_kb_update for update, cwd for sqlite;"
-    echo "         final path is <D>/<version>)"
+    echo "  -D    update/sqlite/hfh mode: download base directory"
+    echo "        (defaults: /tmp/scanoss_kb_update for update, cwd for sqlite and hfh."
+    echo "         Final path: <D>/<version> for update/sqlite, <D>/<version>.zip for hfh.)"
     echo
     echo "Non-interactive flags:"
     echo "  -y    Don't prompt; use defaults for unspecified values, auto-confirm"
@@ -163,7 +164,8 @@ progress_monitor() {
     # $SECONDS resets to 0 in this background subshell, so it tracks elapsed
     # time since the download started rather than since script start.
     while sleep 3; do
-        [[ -d "$dest" ]] || continue
+        # Accept either a directory or a single file (hfh mode downloads a .zip).
+        [[ -e "$dest" ]] || continue
         local current
         current=$(du -sb "$dest" 2>/dev/null | awk '{print $1}')
         [[ -z "$current" || "$current" -eq 0 ]] && continue
@@ -293,6 +295,43 @@ download_path() {
     fi
 }
 
+# Download a single remote file to a local file path (hfh mode). lftp uses
+# pget for parallel chunks of the same file; sftp uses a single-stream get.
+download_file() {
+    local remote_path="$1"
+    local local_path="$2"
+
+    mkdir -p "$(dirname "$local_path")"
+
+    if [[ "$DOWNLOAD_TOOL" == "lftp" ]]; then
+        echo "Downloading ${remote_path} with lftp (${LFTP_THREADS} parallel chunks, resumable)..."
+        lftp -u "$SFTP_USER","$SFTP_PASS" \
+            -e "${LFTP_COMPRESS_SETTINGS} ${LFTP_SETTINGS} pget -c -n ${LFTP_THREADS} $remote_path -o $local_path; exit" \
+            "sftp://${SFTP_HOST}:${SFTP_PORT}"
+    else
+        echo "Downloading ${remote_path} with sftp..."
+        start_progress "$local_path"
+        sshpass -p "$SFTP_PASS" \
+            sftp -P "$SFTP_PORT" -oBatchMode=no -oStrictHostKeyChecking=accept-new $SSH_COMPRESS_FLAGS \
+            "$SFTP_USER@$SFTP_HOST:$remote_path" "$local_path"
+        stop_progress
+    fi
+}
+
+# Return the size in bytes of a single remote file. Used by hfh mode where
+# the KB ships a flat .zip with no metadata.json; the size comes from the
+# 5th column of an `ls -l`-style listing. Note: lftp's `ls -l <file>` is
+# server-passthrough and refuses a non-directory argument, so use `cls -l`
+# (lftp's own client-side listing) instead. Output is empty on failure.
+get_remote_file_size() {
+    local remote_path="$1"
+    if [[ "$DOWNLOAD_TOOL" == "lftp" ]]; then
+        lftp_cmd "cls -l $remote_path" | awk '/^-/ {print $5; exit}'
+    else
+        sftp_cmd "ls -l $remote_path" | awk '/^-/ {print $5; exit}'
+    fi
+}
+
 # Download the full KB with split destinations:
 #   - the "oss" subfolder goes to oss_dest
 #   - everything else goes to rest_dest
@@ -401,14 +440,14 @@ init_download_tool() {
 prompt_missing_mode() {
     if [[ -n "$MODE" ]]; then
         case "$MODE" in
-            full|update|test|sqlite) ;;
-            *) die "Invalid mode: ${MODE}. Use 'full', 'update', 'test', or 'sqlite'." ;;
+            full|update|test|sqlite|hfh) ;;
+            *) die "Invalid mode: ${MODE}. Use 'full', 'update', 'test', 'sqlite', or 'hfh'." ;;
         esac
         return
     fi
 
     if [[ -n "$NON_INTERACTIVE" ]]; then
-        die "Mode is required in non-interactive mode. Pass -m full|update|test|sqlite."
+        die "Mode is required in non-interactive mode. Pass -m full|update|test|sqlite|hfh."
     fi
 
     echo
@@ -417,15 +456,17 @@ prompt_missing_mode() {
     echo "  2) KB update"
     echo "  3) Test KB"
     echo "  4) SQLite KB"
+    echo "  5) HFH KB"
     echo
     while true; do
-        read -p "Select [1-4]: " choice
+        read -p "Select [1-5]: " choice
         case $choice in
             1) MODE="full"; break ;;
             2) MODE="update"; break ;;
             3) MODE="test"; break ;;
             4) MODE="sqlite"; break ;;
-            *) echo "Please enter 1, 2, 3, or 4." ;;
+            5) MODE="hfh"; break ;;
+            *) echo "Please enter 1, 2, 3, 4, or 5." ;;
         esac
     done
 }
@@ -581,15 +622,25 @@ kb_download() {
             label="sqlite KB"
             default_download="."
             ;;
+        hfh)
+            remote_path="$REMOTE_PATH_HFH"
+            label="hfh KB"
+            default_download="."
+            ;;
     esac
 
-    # Discover available versions
+    # Discover available versions. hfh is a flat directory of <version>.zip
+    # files; other modes have versioned subdirectories.
     echo
     echo "Fetching available ${label} versions..."
     log "Fetching available ${label} versions from ${SFTP_HOST}:${remote_path}"
 
     local versions
-    versions=$(list_remote_dirs "$remote_path")
+    if [[ "$mode" == "hfh" ]]; then
+        versions=$(list_remote_items "$remote_path" | grep '\.zip$' | sed 's/\.zip$//' | sort)
+    else
+        versions=$(list_remote_dirs "$remote_path")
+    fi
 
     if [[ -z "$versions" ]]; then
         echo "No ${label} versions found on the server."
@@ -665,8 +716,9 @@ kb_download() {
     echo "Selected ${label}: $kb_version"
     log "Selected ${label} version: $kb_version"
 
-    # Download location(s)
-    local oss_dest="" rest_dest="" download_dir_path="" disk_check_path=""
+    # Download location(s). hfh produces a single .zip file at $hfh_local_file;
+    # other non-full modes produce a directory at $download_dir_path.
+    local oss_dest="" rest_dest="" download_dir_path="" hfh_local_file="" disk_check_path=""
     if [[ "$mode" == "full" ]]; then
         local default_oss_dest="/var/lib/ldb/oss"
         local default_rest_dest="/tmp/scanoss_kb_full_${kb_version}"
@@ -703,64 +755,78 @@ kb_download() {
             read -p "Download directory [${default_download}]: " download_input
             download_base="${download_input:-$default_download}"
         fi
-        download_dir_path="${download_base}/${kb_version}"
+        if [[ "$mode" == "hfh" ]]; then
+            hfh_local_file="${download_base}/${kb_version}.zip"
+        else
+            download_dir_path="${download_base}/${kb_version}"
+        fi
         mkdir -p "$download_base"
         disk_check_path="$download_base"
     fi
 
-    # Fetch metadata and check disk space
+    # Fetch metadata and check disk space. hfh has no metadata.json, so its
+    # size comes from `ls -l` on the remote .zip file instead.
     echo
-    echo "Fetching ${label} metadata..."
-    local metadata_content
-    metadata_content=$(read_remote_file "${remote_path}/${kb_version}/metadata.json" 2>/dev/null || true)
+    local remote_size=""
+    if [[ "$mode" == "hfh" ]]; then
+        echo "Fetching ${label} file size..."
+        remote_size=$(get_remote_file_size "${remote_path}/${kb_version}.zip" 2>/dev/null || true)
+    else
+        echo "Fetching ${label} metadata..."
+        local metadata_content
+        metadata_content=$(read_remote_file "${remote_path}/${kb_version}/metadata.json" 2>/dev/null || true)
+        if [[ -n "$metadata_content" ]]; then
+            remote_size=$(echo "$metadata_content" | grep -oE '"total_size_bytes":[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
+        fi
+    fi
 
-    if [[ -n "$metadata_content" ]]; then
-        local remote_size
-        remote_size=$(echo "$metadata_content" | grep -oE '"total_size_bytes":[[:space:]]*[0-9]+' | grep -oE '[0-9]+$')
+    if [[ -n "$remote_size" && "$remote_size" -gt 0 ]]; then
         REMOTE_SIZE_BYTES="$remote_size"
 
-        if [[ -n "$remote_size" && "$remote_size" -gt 0 ]]; then
-            local local_free
-            local_free=$(df -B1 "$disk_check_path" | awk 'NR==2 {print $4}')
-            local remote_hr
-            remote_hr=$(numfmt --to=iec "$remote_size")
-            local local_hr
-            local_hr=$(numfmt --to=iec "$local_free")
+        local local_free
+        local_free=$(df -B1 "$disk_check_path" | awk 'NR==2 {print $4}')
+        local remote_hr
+        remote_hr=$(numfmt --to=iec "$remote_size")
+        local local_hr
+        local_hr=$(numfmt --to=iec "$local_free")
 
-            echo "${label^} size: ${remote_hr}"
-            echo "Free space:  ${local_hr} (on $(df "$disk_check_path" | awk 'NR==2 {print $1}'))"
+        echo "${label^} size: ${remote_hr}"
+        echo "Free space:  ${local_hr} (on $(df "$disk_check_path" | awk 'NR==2 {print $1}'))"
 
-            if (( local_free < remote_size )); then
-                echo
-                echo "WARNING: Not enough disk space. Need ${remote_hr} but only ${local_hr} available."
-                if [[ "$mode" == "full" ]]; then
-                    echo "(Note: for full KB the 'oss' folder and the remaining files may end up on different"
-                    echo " filesystems. The check above is against ${disk_check_path}.)"
-                fi
-                log "Insufficient disk space for ${kb_version}: need ${remote_hr}, have ${local_hr}"
-                if [[ -n "$NON_INTERACTIVE" ]]; then
-                    if [[ -n "$FORCE_DISK" ]]; then
-                        echo "Continuing despite low disk space (-f)."
-                    else
-                        die "Aborting download: low disk space. Re-run with -f to override."
-                    fi
+        if (( local_free < remote_size )); then
+            echo
+            echo "WARNING: Not enough disk space. Need ${remote_hr} but only ${local_hr} available."
+            if [[ "$mode" == "full" ]]; then
+                echo "(Note: for full KB the 'oss' folder and the remaining files may end up on different"
+                echo " filesystems. The check above is against ${disk_check_path}.)"
+            fi
+            log "Insufficient disk space for ${kb_version}: need ${remote_hr}, have ${local_hr}"
+            if [[ -n "$NON_INTERACTIVE" ]]; then
+                if [[ -n "$FORCE_DISK" ]]; then
+                    echo "Continuing despite low disk space (-f)."
                 else
-                    while true; do
-                        read -p "Continue download anyway? [y/N] " yn
-                        yn="${yn:-n}"
-                        case $yn in
-                            [Yy]*) echo "Continuing despite low disk space."; break ;;
-                            [Nn]*) echo "Aborting download."; return ;;
-                            *)     echo "Please answer yes (y) or no (n)." ;;
-                        esac
-                    done
+                    die "Aborting download: low disk space. Re-run with -f to override."
                 fi
             else
-                echo "Disk space OK."
+                while true; do
+                    read -p "Continue download anyway? [y/N] " yn
+                    yn="${yn:-n}"
+                    case $yn in
+                        [Yy]*) echo "Continuing despite low disk space."; break ;;
+                        [Nn]*) echo "Aborting download."; return ;;
+                        *)     echo "Please answer yes (y) or no (n)." ;;
+                    esac
+                done
             fi
+        else
+            echo "Disk space OK."
         fi
     else
-        echo "WARN: metadata.json not found on server, skipping disk space check."
+        if [[ "$mode" == "hfh" ]]; then
+            echo "WARN: could not determine remote file size, skipping disk space check."
+        else
+            echo "WARN: metadata.json not found on server, skipping disk space check."
+        fi
     fi
 
     # Prompt for thread count if using lftp (skipped under -y)
@@ -774,6 +840,8 @@ kb_download() {
     local prompt_dest
     if [[ "$mode" == "full" ]]; then
         prompt_dest="${oss_dest} + ${rest_dest}"
+    elif [[ "$mode" == "hfh" ]]; then
+        prompt_dest="${hfh_local_file}"
     else
         prompt_dest="${download_dir_path}"
     fi
@@ -800,6 +868,13 @@ kb_download() {
         log "Full KB ${kb_version} downloaded: oss=${oss_dest}, rest=${rest_dest}"
         echo
         echo "Finished downloading full KB."
+    elif [[ "$mode" == "hfh" ]]; then
+        download_file "${remote_path}/${kb_version}.zip" "$hfh_local_file"
+        echo
+        echo "${label^} downloaded to ${hfh_local_file}"
+        log "${label^} ${kb_version} downloaded to ${hfh_local_file}"
+        echo
+        echo "Finished downloading ${label}."
     else
         download_path "${remote_path}/${kb_version}" "$download_dir_path"
         echo

--- a/install/kb-download.sh
+++ b/install/kb-download.sh
@@ -222,9 +222,9 @@ stop_progress() {
 list_remote_dirs() {
     local remote_path="$1"
     if [[ "$DOWNLOAD_TOOL" == "lftp" ]]; then
-        lftp_cmd "ls $remote_path" | awk '/^d/ {print $NF}' | grep -v '^\.\.*$' | sort
+        lftp_cmd "ls \"$remote_path\"" | awk '/^d/ {print $NF}' | grep -v '^\.\.*$' | sort
     else
-        sftp_cmd "ls -l $remote_path" | awk '/^d/ {print $NF}' | sed 's|.*/||' | grep -v '^\.\.*$' | sort
+        sftp_cmd "ls -l \"$remote_path\"" | awk '/^d/ {print $NF}' | sed 's|.*/||' | grep -v '^\.\.*$' | sort
     fi
 }
 
@@ -236,10 +236,10 @@ read_remote_file() {
     rm -f "$tmpfile"
     if [[ "$DOWNLOAD_TOOL" == "lftp" ]]; then
         lftp -u "$SFTP_USER","$SFTP_PASS" \
-            -e "${LFTP_COMPRESS_SETTINGS} ${LFTP_SETTINGS} get $remote_path -o $tmpfile; exit" \
+            -e "${LFTP_COMPRESS_SETTINGS} ${LFTP_SETTINGS} get \"$remote_path\" -o \"$tmpfile\"; exit" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}" &>/dev/null
     else
-        sftp_cmd "get $remote_path $tmpfile" >/dev/null 2>&1
+        sftp_cmd "get \"$remote_path\" \"$tmpfile\"" >/dev/null 2>&1
     fi
     cat "$tmpfile"
     rm -f "$tmpfile"
@@ -250,9 +250,9 @@ read_remote_file() {
 list_remote_items() {
     local remote_path="$1"
     if [[ "$DOWNLOAD_TOOL" == "lftp" ]]; then
-        lftp_cmd "ls $remote_path" | awk '/^[-dl]/ {print $NF}' | grep -v '^\.\.*$' | sort
+        lftp_cmd "ls \"$remote_path\"" | awk '/^[-dl]/ {print $NF}' | grep -v '^\.\.*$' | sort
     else
-        sftp_cmd "ls -l $remote_path" | awk '/^[-dl]/ {print $NF}' | sed 's|.*/||' | grep -v '^\.\.*$' | sort
+        sftp_cmd "ls -l \"$remote_path\"" | awk '/^[-dl]/ {print $NF}' | sed 's|.*/||' | grep -v '^\.\.*$' | sort
     fi
 }
 
@@ -267,7 +267,7 @@ download_path() {
         mkdir -p "$local_path"
         echo "Downloading ${remote_path} with lftp (${LFTP_THREADS} parallel threads, resumable)..."
         lftp -u "$SFTP_USER","$SFTP_PASS" \
-            -e "${LFTP_COMPRESS_SETTINGS} ${LFTP_SETTINGS} mirror -c -P ${LFTP_THREADS} $remote_path $local_path; exit" \
+            -e "${LFTP_COMPRESS_SETTINGS} ${LFTP_SETTINGS} mirror -c -P ${LFTP_THREADS} \"$remote_path\" \"$local_path\"; exit" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
     else
         echo "Downloading ${remote_path} with sftp..."
@@ -282,10 +282,14 @@ download_path() {
 
         # Watch the in-flight directory ($parent_dir/$remote_base) since the
         # final rename only happens after sftp returns.
+        # Run sftp from inside $parent_dir with `.` as the local arg:
+        # OpenSSH sftp's single-shot CLI re-splits the local arg on whitespace
+        # even when bash passes one quoted arg, so a $parent_dir containing
+        # spaces would silently land in the wrong directory.
         start_progress "$parent_dir/$remote_base"
-        sshpass -p "$SFTP_PASS" \
+        ( cd "$parent_dir" && sshpass -p "$SFTP_PASS" \
             sftp -P "$SFTP_PORT" -oBatchMode=no -oStrictHostKeyChecking=accept-new $SSH_COMPRESS_FLAGS \
-            -r "$SFTP_USER@$SFTP_HOST:$remote_path" "$parent_dir"
+            -r "$SFTP_USER@$SFTP_HOST:$remote_path" . )
         stop_progress
 
         if [[ "$remote_base" != "$local_base" ]]; then
@@ -306,14 +310,19 @@ download_file() {
     if [[ "$DOWNLOAD_TOOL" == "lftp" ]]; then
         echo "Downloading ${remote_path} with lftp (${LFTP_THREADS} parallel chunks, resumable)..."
         lftp -u "$SFTP_USER","$SFTP_PASS" \
-            -e "${LFTP_COMPRESS_SETTINGS} ${LFTP_SETTINGS} pget -c -n ${LFTP_THREADS} $remote_path -o $local_path; exit" \
+            -e "${LFTP_COMPRESS_SETTINGS} ${LFTP_SETTINGS} pget -c -n ${LFTP_THREADS} \"$remote_path\" -o \"$local_path\"; exit" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
     else
         echo "Downloading ${remote_path} with sftp..."
+        local local_dir local_base
+        local_dir=$(dirname "$local_path")
+        local_base=$(basename "$local_path")
+        # See download_path for why we cd first instead of passing $local_path
+        # directly: OpenSSH sftp's CLI re-splits the local arg on whitespace.
         start_progress "$local_path"
-        sshpass -p "$SFTP_PASS" \
+        ( cd "$local_dir" && sshpass -p "$SFTP_PASS" \
             sftp -P "$SFTP_PORT" -oBatchMode=no -oStrictHostKeyChecking=accept-new $SSH_COMPRESS_FLAGS \
-            "$SFTP_USER@$SFTP_HOST:$remote_path" "$local_path"
+            "$SFTP_USER@$SFTP_HOST:$remote_path" "$local_base" )
         stop_progress
     fi
 }
@@ -326,9 +335,9 @@ download_file() {
 get_remote_file_size() {
     local remote_path="$1"
     if [[ "$DOWNLOAD_TOOL" == "lftp" ]]; then
-        lftp_cmd "cls -l $remote_path" | awk '/^-/ {print $5; exit}'
+        lftp_cmd "cls -l \"$remote_path\"" | awk '/^-/ {print $5; exit}'
     else
-        sftp_cmd "ls -l $remote_path" | awk '/^-/ {print $5; exit}'
+        sftp_cmd "ls -l \"$remote_path\"" | awk '/^-/ {print $5; exit}'
     fi
 }
 


### PR DESCRIPTION
Adds `-m hfh` for downloading the HFH knowledge base, which on the SFTP server is a flat directory of `<version>.zip` files (no per-version subdirectories and no metadata.json).

Differences from the other modes are isolated to the existing kb_download function via new branches:
  - Version discovery: list .zip files, strip the extension.
  - Disk-space check: file size comes from `ls -l` (lftp uses `cls -l` because its `ls -l` is server-passthrough and refuses a file argument).
  - Download: new download_file helper that uses lftp `pget -c -n N` for parallel chunks of the same file, or sftp single-stream `get`.
  - Default destination: cwd, final path `<base>/<version>.zip`.

Also widens the progress monitor's exists-check from -d to -e so it works on file destinations (sftp branch of download_file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “HFH KB” download mode with a dedicated workflow.
  * HFH now downloads as a single, versioned `.zip` archive and updates the interactive menu and command-line options accordingly.

* **Documentation**
  * Updated the installation guide, walkthrough, and example sessions to describe HFH behavior and expected archive naming.

* **Bug Fixes**
  * Improved HFH-specific version discovery, size/disk checks, and completion handling for single-file downloads.
  * Enhanced remote download command handling to avoid issues with whitespace in paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->