### PR TITLE
update KB disk requirements according to 26.06 version

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -60,7 +60,7 @@ The following is recommended for running the SCANOSS Applications and SCANOSS KB
 |-----|---------------------------|---------------------------|
 | **CPU** | 8 Core x64 - 3.5 Ghz      | 32 Core x64 - 3.6 Ghz     |
 | **RAM** | 32GB                      | 128GB                     |
-| **HDD** | 23TB SSD (NVMe preferred) | 24TB SSD (NVMe preferred) |
+| **HDD** | 23.5TB SSD (NVMe preferred) | 24TB SSD (NVMe preferred) |
 
 ### Test Knowledge Base Requirements
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the on-premise hardware requirements guidance for the Full Knowledge Base section.
  * Increased the recommended minimum HDD size from 23TB to 23.5TB, with SSD/NVMe still preferred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->