### PR TITLE
update KB disk requirements according to 26.07 version

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -60,7 +60,7 @@ The following is recommended for running the SCANOSS Applications and SCANOSS KB
 |-----|---------------------------|---------------------------|
 | **CPU** | 8 Core x64 - 3.5 Ghz      | 32 Core x64 - 3.6 Ghz     |
 | **RAM** | 32GB                      | 128GB                     |
-| **HDD** | 23.5TB SSD (NVMe preferred) | 24TB SSD (NVMe preferred) |
+| **HDD** | 24TB SSD (NVMe preferred) | 26TB SSD (NVMe preferred) |
 
 ### Test Knowledge Base Requirements
 


### PR DESCRIPTION
Updated Full KB hardware requirements for 26.07.

Current full KB size (measured on s5, /sftp-data/kb/ldb/md5/full/26.07/oss/, du --block-size=1G): 24046 GB.

Recent trend (same measurement, same folder, month over month):

26.05: 22839 GB
26.06: 23486 GB (+647 GB)
26.07: 24046 GB (+560 GB)
Minimum was bumped to 24TB to reflect the current measured size. Since Recommended had stayed fixed at 24TB since 26.02, Minimum was about to catch up to it with no margin left, so Recommended was also bumped to 26TB to restore headroom. Flagging in case a different margin is preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated hardware requirements for the full knowledge base:
    * Minimum storage: 24 TB SSD
    * Recommended storage: 26 TB SSD

<!-- end of auto-generated comment: release notes by coderabbit.ai -->